### PR TITLE
Various compatibility fixes

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -81,7 +81,7 @@ class Component extends React.Component {
     return should;
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     if (props.type !== this.props.type) {
       this.typeInfo = getTypeInfo(props.type);
     }
@@ -592,7 +592,7 @@ export class List extends Component {
     this.state.keys = this.state.value.map(() => props.ctx.uidGenerator.next());
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     if (props.type !== this.props.type) {
       this.typeInfo = getTypeInfo(props.type);
     }

--- a/lib/components.js
+++ b/lib/components.js
@@ -156,7 +156,7 @@ class Component extends React.Component {
       label = null;
     } else if (Nil.is(label) && this.getAuto() === "labels") {
       label = this.getDefaultLabel();
-    } else if (label) {
+    } else if (typeof label === "string") {
       label =
         label +
         (this.typeInfo.isMaybe


### PR DESCRIPTION
- Add `UNSAFE_` prefix to `componentWillReceiveProps` to suppress warnings
- Check label data type to allow the label to be a valid react element